### PR TITLE
wip: CI/CDの自動化のためGithubActionsのworkflowを実装

### DIFF
--- a/.github/workflows/pytest-and-sls-deploy.yml
+++ b/.github/workflows/pytest-and-sls-deploy.yml
@@ -1,0 +1,60 @@
+name: Test and Deploy main branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install pipenv
+        run: python -m pip install --upgrade pip pipenv
+      - name: install dependencies
+        run: pipenv install
+      - name: run tests
+        run: pipenv run pytest
+  deploy:
+    name: deploy
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    # - name: Configure AWS credentials
+    #   uses: aws-actions/configure-aws-credentials@v4
+    #   with:
+    #     aws-region: ap-northeast-1
+    #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    # - name: serverless config
+    #   run: npx serverless config credentials --provider aws --key ${{ secrets.AWS_ACCESS_KEY_ID }} --secret ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - name: serverless install
+      run: |
+        npm install -g serverless
+        sls --version
+    - name: serverless deploy
+      run: serverless deploy --debug
+      env: 
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,3 @@
 # python
 __pycache__
 .pytest_cache
-
-# github
-.github


### PR DESCRIPTION
#1 

結論：Serverless Frameworkをv4からv3にするのが早い・v4だとクレデンシャルが面倒

同じようなissueがあって参考にしながら試行錯誤したがクレデンシャルが通らない
https://github.com/serverless/serverless/issues/12534

v3に戻せば下記でいつも通りにできるので戻せば良い
```yml
run: npx serverless config credentials --provider aws --key ${{ secrets.AWS_ACCESS_KEY_ID }} --secret ${{ secrets.AWS_SECRET_ACCESS_KEY }}
```

だがv3はpython3.11までしか使えないことが懸念点（3.11でも問題なく動く）
今回はここまでにしよう